### PR TITLE
Add PoC skeleton for shared, server, and app modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+# FoodNutrients PoC
+
+Monorepo skeleton for the dietitian nutrient application.
+
+- `packages/shared` – shared TypeScript utilities (nutrient definitions, profiles, units)
+- `server` – Fastify API proxy and seed loader
+- `app` – React Native application skeleton

--- a/app/App.tsx
+++ b/app/App.tsx
@@ -1,0 +1,11 @@
+import React from "react";
+import { SafeAreaView } from "react-native";
+import { SearchScreen } from "./src/screens/SearchScreen";
+
+export default function App() {
+  return (
+    <SafeAreaView style={{ flex: 1 }}>
+      <SearchScreen />
+    </SafeAreaView>
+  );
+}

--- a/app/package.json
+++ b/app/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "app",
+  "version": "0.0.1",
+  "main": "App.tsx",
+  "type": "module",
+  "dependencies": {
+    "react": "^18.0.0",
+    "react-native": "0.72.0",
+    "axios": "^1.0.0"
+  }
+}

--- a/app/src/api/client.ts
+++ b/app/src/api/client.ts
@@ -1,0 +1,2 @@
+import axios from "axios";
+export const api = axios.create({ baseURL: "http://localhost:8080/api" });

--- a/app/src/components/NutrientList.tsx
+++ b/app/src/components/NutrientList.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+import { View, Text } from "react-native";
+
+export function NutrientList() {
+  return (
+    <View>
+      <Text>Nutrient List</Text>
+    </View>
+  );
+}

--- a/app/src/components/PercentBars.tsx
+++ b/app/src/components/PercentBars.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+import { View, Text } from "react-native";
+
+export function PercentBars() {
+  return (
+    <View>
+      <Text>Percent Bars</Text>
+    </View>
+  );
+}

--- a/app/src/screens/FoodDetailScreen.tsx
+++ b/app/src/screens/FoodDetailScreen.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+import { View, Text } from "react-native";
+
+export function FoodDetailScreen() {
+  return (
+    <View>
+      <Text>Food Detail</Text>
+    </View>
+  );
+}

--- a/app/src/screens/ProfileSelectScreen.tsx
+++ b/app/src/screens/ProfileSelectScreen.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+import { View, Text } from "react-native";
+
+export function ProfileSelectScreen() {
+  return (
+    <View>
+      <Text>Profile Select</Text>
+    </View>
+  );
+}

--- a/app/src/screens/SearchScreen.tsx
+++ b/app/src/screens/SearchScreen.tsx
@@ -1,0 +1,23 @@
+import React, { useState } from "react";
+import { View, TextInput, Text, FlatList, Pressable } from "react-native";
+import { api } from "../api/client";
+
+export function SearchScreen() {
+  const [q, setQ] = useState("");
+  const [items, setItems] = useState<any[]>([]);
+
+  async function onSearch() {
+    const res = await api.get("/search", { params: { q, lang: "tr" } });
+    setItems(res.data.items);
+  }
+
+  return (
+    <View style={{ padding: 16 }}>
+      <TextInput value={q} onChangeText={setQ} placeholder="Besin ara" style={{ borderWidth: 1, padding: 8 }} />
+      <Pressable onPress={onSearch} style={{ marginTop: 8 }}><Text>Ara</Text></Pressable>
+      <FlatList data={items} keyExtractor={(x) => String(x.fdcId)} renderItem={({ item }) => (
+        <Text>{item.name_en}</Text>
+      )} />
+    </View>
+  );
+}

--- a/app/src/store/useAppStore.ts
+++ b/app/src/store/useAppStore.ts
@@ -1,0 +1,7 @@
+import { useState } from "react";
+
+// Simple placeholder store using React state
+export function useAppStore() {
+  const [profile, setProfile] = useState("general_ri");
+  return { profile, setProfile };
+}

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@shared",
+  "version": "0.0.1",
+  "main": "src/index.ts",
+  "type": "module"
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,0 +1,3 @@
+export * from "./nutrients-tr";
+export * from "./profiles-tr";
+export * from "./units";

--- a/packages/shared/src/nutrients-tr.ts
+++ b/packages/shared/src/nutrients-tr.ts
@@ -1,0 +1,47 @@
+export type NutrientKey =
+  | "energy_kcal"
+  | "protein_g"
+  | "fat_g"
+  | "sat_fat_g"
+  | "carb_g"
+  | "sugars_g"
+  | "fiber_g"
+  | "salt_g"
+  | "sodium_mg"
+  | "vit_a_rae_µg"
+  | "vit_c_mg"
+  | "vit_d_µg"
+  | "calcium_mg"
+  | "iron_mg"
+  | "folate_µg_dfe";
+
+export interface NutrientDef {
+  key: NutrientKey;
+  name_tr: string;
+  unit: "kcal" | "g" | "mg" | "µg";
+  fdcIds?: number[]; // eşleşen FDC nutrient id’leri
+  compute?: (v: Record<string, number>) => number; // Na→Tuz vb.
+}
+
+export const NUTRIENTS_TR: NutrientDef[] = [
+  { key: "energy_kcal", name_tr: "Enerji", unit: "kcal" },
+  { key: "protein_g", name_tr: "Protein", unit: "g" },
+  { key: "fat_g", name_tr: "Toplam Yağ", unit: "g" },
+  { key: "sat_fat_g", name_tr: "Doymuş Yağ", unit: "g" },
+  { key: "carb_g", name_tr: "Karbonhidrat", unit: "g" },
+  { key: "sugars_g", name_tr: "Şeker", unit: "g" },
+  { key: "fiber_g", name_tr: "Lif", unit: "g" },
+  { key: "sodium_mg", name_tr: "Sodyum", unit: "mg" },
+  {
+    key: "salt_g",
+    name_tr: "Tuz",
+    unit: "g",
+    compute: (v) => (v["sodium_mg"] || 0) * 2.5 / 1000, // mg Na → g Tuz
+  },
+  { key: "calcium_mg", name_tr: "Kalsiyum", unit: "mg" },
+  { key: "iron_mg", name_tr: "Demir", unit: "mg" },
+  { key: "vit_c_mg", name_tr: "C Vitamini", unit: "mg" },
+  { key: "vit_d_µg", name_tr: "D Vitamini", unit: "µg" },
+  { key: "vit_a_rae_µg", name_tr: "A Vitamini (RAE)", unit: "µg" },
+  { key: "folate_µg_dfe", name_tr: "Folat (DFE)", unit: "µg" },
+];

--- a/packages/shared/src/profiles-tr.ts
+++ b/packages/shared/src/profiles-tr.ts
@@ -1,0 +1,22 @@
+export interface Profile {
+  id: string;
+  label_tr: string;
+  age_range: string;
+  sex?: "female" | "male" | "unisex";
+  energy_kcal?: number; // TBC
+  dv: Partial<Record<string, number>>; // anahtarlar NutrientKey ile uyumlu
+}
+
+export const PROFILES: Profile[] = [
+  { id: "general_ri", label_tr: "Genel RI (Etiket)", age_range: "—", sex: "unisex", dv: {
+    fat_g: 70, sat_fat_g: 20, carb_g: 260, sugars_g: 90, protein_g: 50, salt_g: 6, fiber_g: 25,
+    // Diğerleri TBC: vit_a_rae_µg, vit_c_mg, vit_d_µg, calcium_mg, iron_mg, folate_µg_dfe, ...
+  } },
+  { id: "adult_female_19_50", label_tr: "Yetişkin Kadın (19–50)", age_range: "19–50", sex: "female", dv: { /* TBC */ } },
+  { id: "adult_male_19_50",   label_tr: "Yetişkin Erkek (19–50)",  age_range: "19–50", sex: "male",   dv: { /* TBC */ } },
+  { id: "adult_female_51_plus", label_tr: "Yetişkin Kadın (51+)", age_range: "51+", sex: "female", dv: { /* TBC */ } },
+  { id: "adult_male_51_plus",   label_tr: "Yetişkin Erkek (51+)",  age_range: "51+", sex: "male",   dv: { /* TBC */ } },
+  { id: "adolescent_14_18", label_tr: "Adölesan (14–18)", age_range: "14–18", sex: "unisex", dv: { /* TBC */ } },
+  { id: "child_9_13", label_tr: "Çocuk (9–13)", age_range: "9–13", sex: "unisex", dv: { /* TBC */ } },
+  { id: "child_4_8",  label_tr: "Çocuk (4–8)",  age_range: "4–8",  sex: "unisex", dv: { /* TBC */ } },
+];

--- a/packages/shared/src/units.ts
+++ b/packages/shared/src/units.ts
@@ -1,0 +1,4 @@
+// Birim dönüşümleri ve hesaplamalar için placeholder
+export function sodiumToSalt(sodiumMg: number): number {
+  return (sodiumMg || 0) * 2.5 / 1000;
+}

--- a/server/.env.sample
+++ b/server/.env.sample
@@ -1,0 +1,4 @@
+PORT=8080
+FDC_API_KEY=REPLACE_ME
+REDIS_URL=redis://localhost:6379
+SEED_JSON_URL=https://raw.githubusercontent.com/sisbas/FoodNutrients/c12ac08a78bedbb803716b07ce5085174f762fbf/FoodData_Central_foundation_food_json_2025-04-24.json

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "server",
+  "version": "0.0.1",
+  "type": "module",
+  "dependencies": {
+    "fastify": "^4.0.0",
+    "@fastify/cors": "^8.0.0",
+    "node-fetch": "^3.0.0"
+  }
+}

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,0 +1,12 @@
+import Fastify from "fastify";
+import cors from "@fastify/cors";
+import { registerRoutes } from "./routes";
+
+const app = Fastify({ logger: true });
+app.register(cors, { origin: true });
+registerRoutes(app);
+
+const port = Number(process.env.PORT || 8080);
+app.listen({ port, host: "0.0.0.0" }).then(() => {
+  app.log.info(`API listening on :${port}`);
+});

--- a/server/src/middlewares/error.ts
+++ b/server/src/middlewares/error.ts
@@ -1,0 +1,7 @@
+import { FastifyInstance } from "fastify";
+
+export function registerErrorHandler(app: FastifyInstance) {
+  app.setErrorHandler((err, req, reply) => {
+    reply.status(500).send({ error: { message: err.message } });
+  });
+}

--- a/server/src/middlewares/rateLimit.ts
+++ b/server/src/middlewares/rateLimit.ts
@@ -1,0 +1,5 @@
+import { FastifyInstance } from "fastify";
+
+export function registerRateLimit(app: FastifyInstance) {
+  // Placeholder for rate limiting middleware
+}

--- a/server/src/routes/foods.ts
+++ b/server/src/routes/foods.ts
@@ -1,0 +1,11 @@
+import { FastifyInstance } from "fastify";
+import { getFoodDetail } from "../services/fdc";
+
+export default async function (app: FastifyInstance) {
+  app.get("/foods/:fdcId", async (req, reply) => {
+    const { fdcId } = req.params as any;
+    const { measure = "100g", grams, profile = "general_ri" } = (req.query as any) || {};
+    const data = await getFoodDetail(String(fdcId), String(measure), grams ? Number(grams) : undefined, String(profile));
+    return data;
+  });
+}

--- a/server/src/routes/health.ts
+++ b/server/src/routes/health.ts
@@ -1,0 +1,7 @@
+import { FastifyInstance } from "fastify";
+
+export default async function (app: FastifyInstance) {
+  app.get("/health", async () => {
+    return { ok: true };
+  });
+}

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -1,0 +1,14 @@
+import { FastifyInstance } from "fastify";
+import health from "./health";
+import search from "./search";
+import foods from "./foods";
+import profiles from "./profiles";
+import nutrients from "./nutrients";
+
+export function registerRoutes(app: FastifyInstance) {
+  app.register(health, { prefix: "/api" });
+  app.register(search, { prefix: "/api" });
+  app.register(foods, { prefix: "/api" });
+  app.register(profiles, { prefix: "/api" });
+  app.register(nutrients, { prefix: "/api" });
+}

--- a/server/src/routes/nutrients.ts
+++ b/server/src/routes/nutrients.ts
@@ -1,0 +1,8 @@
+import { FastifyInstance } from "fastify";
+import { NUTRIENTS_TR } from "@shared";
+
+export default async function (app: FastifyInstance) {
+  app.get("/nutrients", async () => {
+    return { items: NUTRIENTS_TR };
+  });
+}

--- a/server/src/routes/profiles.ts
+++ b/server/src/routes/profiles.ts
@@ -1,0 +1,8 @@
+import { FastifyInstance } from "fastify";
+import { PROFILES } from "@shared";
+
+export default async function (app: FastifyInstance) {
+  app.get("/profiles", async () => {
+    return { items: PROFILES };
+  });
+}

--- a/server/src/routes/search.ts
+++ b/server/src/routes/search.ts
@@ -1,0 +1,10 @@
+import { FastifyInstance } from "fastify";
+import { searchFoods } from "../services/fdc";
+
+export default async function (app: FastifyInstance) {
+  app.get("/search", async (req, reply) => {
+    const { q = "", category = "", lang = "tr", limit = 20 } = (req.query as any) || {};
+    const results = await searchFoods(String(q), String(category), String(lang), Number(limit));
+    return { items: results };
+  });
+}

--- a/server/src/services/cache.ts
+++ b/server/src/services/cache.ts
@@ -1,0 +1,10 @@
+// Simple in-memory cache placeholder
+const cache = new Map<string, any>();
+
+export function getCache<T>(key: string): T | undefined {
+  return cache.get(key);
+}
+
+export function setCache(key: string, value: any) {
+  cache.set(key, value);
+}

--- a/server/src/services/fdc.ts
+++ b/server/src/services/fdc.ts
@@ -1,0 +1,50 @@
+import fetch from "node-fetch";
+import { NUTRIENTS_TR, PROFILES } from "@shared";
+
+const SEED_URL = process.env.SEED_JSON_URL!;
+const FDC_API_KEY = process.env.FDC_API_KEY;
+
+// Basit in-memory cache (PoC); prod’da Redis/Edge KV kullanın
+const memory = new Map<string, any>();
+
+export async function searchFoods(q: string, category: string, lang: string, limit: number) {
+  // 1) Seed’ten basit arama
+  const seed = await loadSeed();
+  const items = seed.filter((x: any) => String(x.description || "").toLowerCase().includes(q.toLowerCase())).slice(0, limit);
+  // 2) (Opsiyon) FDC API çağrısı ile zenginleştirme…
+  return items.map((x: any) => ({ fdcId: x.fdcId, name_en: x.description }));
+}
+
+export async function getFoodDetail(fdcId: string, measure: string, grams: number | undefined, profileId: string) {
+  const seed = await loadSeed();
+  const item = seed.find((x: any) => String(x.fdcId) === String(fdcId));
+  if (!item) throw new Error("Food not found");
+
+  // çok basit normalizasyon (PoC): 100 g değerlerini çıkar
+  const per100: Record<string, number> = {};
+  for (const n of item.foodNutrients || []) {
+    // burada FDC nutrient id → internal key eşleme yapılmalı (NUTRIENTS_TR ile)
+    // PoC’ta enerji/protein/yağ/kh gibi alanları tahmini anahtarlarla doldurun.
+  }
+
+  const gramsFinal = measure === "custom" && grams ? grams : (measure === "serving" ? 100 : 100); // PoC olarak 100g kabul
+  const scaled: Record<string, number> = {};
+  Object.entries(per100).forEach(([k, v]) => { scaled[k] = v * gramsFinal / 100; });
+
+  const profile = PROFILES.find(p => p.id === profileId) || PROFILES[0];
+  const percentages: Record<string, number> = {};
+  Object.entries(scaled).forEach(([k, v]) => {
+    const dv = (profile as any).dv[k];
+    if (typeof dv === "number" && dv > 0) percentages[k] = v / dv * 100;
+  });
+
+  return { fdcId, measure, grams: gramsFinal, per100, values: scaled, percentages, profile: profile.id };
+}
+
+async function loadSeed(): Promise<any[]> {
+  if (memory.has("seed")) return memory.get("seed");
+  const res = await fetch(SEED_URL);
+  const json = await res.json();
+  memory.set("seed", json);
+  return json;
+}

--- a/server/src/services/mapping.ts
+++ b/server/src/services/mapping.ts
@@ -1,0 +1,5 @@
+// Placeholder for FDC → internal model mappings
+export function mapNutrientId(id: number): string | undefined {
+  // TODO: implement mapping
+  return undefined;
+}

--- a/server/src/services/seed.ts
+++ b/server/src/services/seed.ts
@@ -1,0 +1,7 @@
+import fetch from "node-fetch";
+
+// Placeholder for seed JSON loader
+export async function loadSeedFromUrl(url: string): Promise<any[]> {
+  const res = await fetch(url);
+  return res.json();
+}


### PR DESCRIPTION
## Summary
- set up shared nutrient and profile definitions
- create Fastify server skeleton with basic routes
- scaffold React Native app with search screen

## Testing
- `npm test` (server) *(fails: Missing script "test")*
- `npm test` (app) *(fails: Missing script "test")*
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895ebbcbd28832b8a66f9b61f724cdc