### PR TITLE
Add shared utilities and Supabase schema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+node_modules/
+.env
+*.log
+app/package-lock.json
+server/package-lock.json
+packages/*/package-lock.json
+

--- a/README.md
+++ b/README.md
@@ -2,6 +2,25 @@
 
 Monorepo skeleton for the dietitian nutrient application.
 
-- `packages/shared` – shared TypeScript utilities (nutrient definitions, profiles, units)
-- `server` – Fastify API proxy and seed loader
-- `app` – React Native application skeleton
+## Yapı
+- `packages/shared` – Ortak TypeScript yardımcıları (nutrient tanımları, profiller, birim dönüşümleri)
+- `server` – Fastify API proxy ve seed yükleyici
+- `app` – React Native uygulama iskeleti
+- `supabase` – Şema ve RLS politikaları
+
+## Kurulum
+```bash
+npm install
+```
+
+Gerekli ortam değişkenleri için `server/.env.sample` dosyasını `.env` olarak kopyalayın ve değerleri doldurun.
+
+## Çalıştırma
+Bu PoC yalnızca test ve servis fonksiyonlarını içerir.
+
+## Test
+```bash
+npm test
+```
+
+> Not: Bu ortamda `vitest` bağımlılıkları indirilemeyebilir.

--- a/__tests__/__snapshots__/pdf.test.ts.snap
+++ b/__tests__/__snapshots__/pdf.test.ts.snap
@@ -1,0 +1,1 @@
+exports[`pdf html matches snapshot 1`] = `<!DOCTYPE html><html><head><meta charset="utf-8"/><title>Sample</title></head><body><h1>Sample</h1><table><tr><td>Protein</td><td>5</td><td>10</td><td>20%</td></tr></table></body></html>`;

--- a/__tests__/dv.test.ts
+++ b/__tests__/dv.test.ts
@@ -1,0 +1,15 @@
+import { sodiumToSalt } from '@shared';
+import { calculatePercentage } from '@server/services/dv';
+import { describe, it, expect } from 'vitest';
+
+describe('unit conversions', () => {
+  it('converts sodium to salt', () => {
+    expect(sodiumToSalt(400)).toBeCloseTo(1);
+  });
+});
+
+describe('%DV calculations', () => {
+  it('computes percentage', () => {
+    expect(calculatePercentage(5, 10)).toBe(50);
+  });
+});

--- a/__tests__/mapping.test.ts
+++ b/__tests__/mapping.test.ts
@@ -1,0 +1,17 @@
+import { mapFdcNutrients } from '@server/services/mapping';
+import { describe, it, expect } from 'vitest';
+
+describe('mapping', () => {
+  it('maps known nutrients', () => {
+    const list = [
+      { nutrient: { name: 'Energy', unitName: 'kcal' }, amount: 100 },
+      { nutrient: { name: 'Protein', unitName: 'g' }, amount: 10 },
+      { nutrient: { name: 'Sodium, Na', unitName: 'mg' }, amount: 200 },
+    ];
+    const result = mapFdcNutrients(list);
+    expect(result.energy_kcal).toBe(100);
+    expect(result.protein_g).toBe(10);
+    expect(result.sodium_mg).toBe(200);
+    expect(result.salt_g).toBeCloseTo(0.5);
+  });
+});

--- a/__tests__/pdf.test.ts
+++ b/__tests__/pdf.test.ts
@@ -1,0 +1,12 @@
+import { generateHtml } from '@server/services/pdf';
+import { describe, it, expect } from 'vitest';
+
+describe('pdf html', () => {
+  it('matches snapshot', () => {
+    const html = generateHtml({
+      title: 'Sample',
+      rows: [{ label: 'Protein', per100: 5, value: 10, percent: 20 }]
+    });
+    expect(html).toMatchSnapshot();
+  });
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "foodnutrients-monorepo",
+  "private": true,
+  "version": "0.1.0",
+  "workspaces": ["packages/*", "server", "app"],
+  "scripts": {
+    "test": "vitest"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0",
+    "vitest": "^1.0.0"
+  }
+}

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@shared",
+  "name": "shared",
   "version": "0.0.1",
   "main": "src/index.ts",
   "type": "module"

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,3 +1,4 @@
 export * from "./nutrients-tr";
 export * from "./profiles-tr";
 export * from "./units";
+export * from "./search-synonyms-tr";

--- a/packages/shared/src/search-synonyms-tr.ts
+++ b/packages/shared/src/search-synonyms-tr.ts
@@ -1,0 +1,5 @@
+export const SEARCH_SYNONYMS_TR: Record<string, string[]> = {
+  "bulgur": ["buğday kırığı"],
+  "şalgam suyu": ["şalgam içeceği"],
+  "taze soğan": ["yeşil soğan"],
+};

--- a/server/.env.sample
+++ b/server/.env.sample
@@ -1,4 +1,7 @@
 PORT=8080
+SEED_JSON_URL=https://raw.githubusercontent.com/sisbas/FoodNutrients/refs/heads/main/FoodData_Central_foundation_food_json_2025-04-24.json
 FDC_API_KEY=REPLACE_ME
-REDIS_URL=redis://localhost:6379
-SEED_JSON_URL=https://raw.githubusercontent.com/sisbas/FoodNutrients/c12ac08a78bedbb803716b07ce5085174f762fbf/FoodData_Central_foundation_food_json_2025-04-24.json
+SUPABASE_URL=REPLACE_ME
+SUPABASE_ANON_KEY=REPLACE_ME
+SUPABASE_SERVICE_ROLE=REPLACE_ME
+TRIAL_DAYS=180

--- a/server/src/services/dv.ts
+++ b/server/src/services/dv.ts
@@ -1,0 +1,4 @@
+export function calculatePercentage(value: number, dailyValue: number): number {
+  if (!dailyValue) return 0;
+  return value / dailyValue * 100;
+}

--- a/server/src/services/mapping.ts
+++ b/server/src/services/mapping.ts
@@ -1,5 +1,26 @@
-// Placeholder for FDC → internal model mappings
-export function mapNutrientId(id: number): string | undefined {
-  // TODO: implement mapping
-  return undefined;
+import { NUTRIENTS_TR } from "@shared";
+
+const NAME_UNIT_MAP: Record<string, string> = {
+  "Energy|kcal": "energy_kcal",
+  "Protein|g": "protein_g",
+  "Total lipid (fat)|g": "fat_g",
+  "Carbohydrate, by difference|g": "carb_g",
+  "Fiber, total dietary|g": "fiber_g",
+  "Sodium, Na|mg": "sodium_mg",
+};
+
+export interface FdcNutrient {
+  nutrient: { name: string; unitName: string };
+  amount: number;
+}
+
+export function mapFdcNutrients(list: FdcNutrient[]): Record<string, number> {
+  const out: Record<string, number> = {};
+  for (const item of list) {
+    const key = NAME_UNIT_MAP[`${item.nutrient.name}|${item.nutrient.unitName}`];
+    if (key) out[key] = item.amount;
+  }
+  const saltDef = NUTRIENTS_TR.find(n => n.key === "salt_g");
+  if (saltDef?.compute) out["salt_g"] = saltDef.compute(out);
+  return out;
 }

--- a/server/src/services/pdf.ts
+++ b/server/src/services/pdf.ts
@@ -1,0 +1,8 @@
+interface Row { label: string; per100: number; value: number; percent: number; }
+
+export function generateHtml(data: { title: string; rows: Row[] }) {
+  const rows = data.rows.map(r =>
+    `<tr><td>${r.label}</td><td>${r.per100}</td><td>${r.value}</td><td>${r.percent.toFixed(0)}%</td></tr>`
+  ).join("");
+  return `<!DOCTYPE html><html><head><meta charset="utf-8"/><title>${data.title}</title></head><body><h1>${data.title}</h1><table>${rows}</table></body></html>`;
+}

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -1,0 +1,53 @@
+-- Supabase schema for dietitian nutrient application
+
+create table if not exists users (
+  id uuid primary key default gen_random_uuid(),
+  created_at timestamptz default now(),
+  locale text default 'tr'
+);
+
+create table if not exists subscriptions (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid references users(id),
+  plan text default 'trial',
+  status text default 'active',
+  trial_started_at timestamptz,
+  trial_ends_at timestamptz
+);
+
+create table if not exists favorites (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid references users(id),
+  fdc_id bigint,
+  name text,
+  created_at timestamptz default now(),
+  unique (user_id, fdc_id)
+);
+
+create table if not exists recents (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid references users(id),
+  fdc_id bigint,
+  name text,
+  viewed_at timestamptz default now(),
+  unique (user_id, fdc_id)
+);
+
+create table if not exists profile_settings (
+  user_id uuid primary key references users(id),
+  profile_id text,
+  updated_at timestamptz default now()
+);
+
+-- RLS
+alter table users enable row level security;
+alter table subscriptions enable row level security;
+alter table favorites enable row level security;
+alter table recents enable row level security;
+alter table profile_settings enable row level security;
+
+-- Policies: user can manage own records
+create policy "Users manage own data" on favorites for all using (auth.uid() = user_id) with check (auth.uid() = user_id);
+create policy "Users manage own data" on recents for all using (auth.uid() = user_id) with check (auth.uid() = user_id);
+create policy "Users manage own settings" on profile_settings for all using (auth.uid() = user_id) with check (auth.uid() = user_id);
+create policy "Service role manages subscriptions" on subscriptions for all using (auth.role() = 'service_role') with check (auth.role() = 'service_role');

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "baseUrl": ".",
+    "paths": {
+      "@shared/*": ["packages/shared/src/*"],
+      "@server/*": ["server/src/*"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- setup monorepo config with TypeScript paths and workspace test scripts
- add shared nutrient synonyms and DV helpers
- include Supabase SQL schema and server env sample
- basic service layer for nutrient mapping and PDF HTML generation with tests

## Testing
- `npm install` *(fails: 403 Forbidden for typescript)*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68960161c4dc832b84ab42c7bfc2cf2c